### PR TITLE
*.entry_date as string

### DIFF
--- a/db/create_database.sh
+++ b/db/create_database.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-
+MAPLOC="$(dirname $0)"
 HOST=${1:-"localhost:9200"}
 curl -XPUT http://$HOST/public_titles
 
 curl -XPUT http://$HOST/authenticated_titles
+
+curl -XPUT http://$HOST/_all/_mapping/titles -d @${MAPLOC}/mapping.json
 

--- a/db/mapping.json
+++ b/db/mapping.json
@@ -1,0 +1,15 @@
+{
+    "titles" : {
+        "dynamic_templates": [
+            {
+                "dates_as_strings_template": {
+                    "path_match": "*.entry_date",
+                    "mapping": {
+                        "type": "string",
+                        "index": "not_analyzed"
+                    }
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
@ashimali OK, I've tried dates like "2014-rubbish10-11" now and it gets through.

Viewed the title in the various frontends, and no jinja2 complaints.
